### PR TITLE
Apply patch from https://github.com/libigl/libigl/pull/2215

### DIFF
--- a/cmake/recipes/external/gmp.cmake
+++ b/cmake/recipes/external/gmp.cmake
@@ -34,11 +34,11 @@ else()
 
   ExternalProject_Add(gmp
     PREFIX ${prefix}
-    URL  https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
-    URL_MD5 0b82665c4a92fd2ade7440c13fcaa42b
+    URL  https://github.com/alisw/GMP/archive/refs/tags/v6.2.1.tar.gz
+    URL_MD5 f060ad4e762ae550d16f1bb477aadba5
     UPDATE_DISCONNECTED true  # need this to avoid constant rebuild
     PATCH_COMMAND 
-      curl "https://gmplib.org/repo/gmp/raw-rev/5f32dbc41afc" "|" git apply -v
+      curl "https://gist.githubusercontent.com/alecjacobson/d34d9307c17d1b853571699b9786e9d1/raw/8d14fc21cb7654f51c2e8df4deb0f82f9d0e8355/gmp-patch" "|" git apply -v
     ${gmp_ExternalProject_Add_extra_options}
     CONFIGURE_COMMAND 
       ${prefix}/src/gmp/configure 


### PR DESCRIPTION
- This [dev suite PR](https://github.com/Machina-Labs/machina_dev_suite/pull/180) adds CI that builds libigl
- Libigl has a [fix](https://github.com/libigl/libigl/pull/2215) needed so that it doesn't fail in github-hosted runners in our CI
- Root cause was some open source vs Microsoft [drama](https://www.theregister.com/2023/06/28/microsofts_github_gmp_project/) 🍿 